### PR TITLE
Add support for options and args passing to casperjs

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -23,6 +23,14 @@ module.exports = function (grunt) {
           'tmp/casper/testPass-results.xml' : ['test/fixtures/testPass.js']
         }
       },
+      args: {
+        options: {
+          test: false
+        },
+        files: {
+          'tmp/casper/testArgs-results.xml': ['test/fixtures/testArgs.js']
+        }
+      },
       fail : {
         files : {
           'tmp/casper/testFail-results.xml' : ['test/fixtures/testFail.js']
@@ -66,7 +74,15 @@ module.exports = function (grunt) {
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-contrib-clean');
   grunt.loadNpmTasks('grunt-contrib-internal');
-  grunt.registerTask('caspertests', ['clean', 'casper:pass', 'casper:multiple', 'casper:includes', 'casper:screenshots','spawnFailure']);
+  
+  /* can't pass arguments to alias tasks but we can use grunt.task.run */
+  grunt.registerTask('casperargs', function() {
+    var args = ['casper','args'].concat(Array.prototype.slice.call(arguments));
+    grunt.log.writeln(args.join(':'));
+    grunt.task.run(args.join(':'));
+  });
+  
+  grunt.registerTask('caspertests', ['clean', 'casper:pass', 'casperargs:baz:--foo=bar', 'casper:multiple', 'casper:includes', 'casper:screenshots','spawnFailure']);
 
   grunt.registerTask('test', ['jshint', 'caspertests', 'nodeunit']);
   grunt.registerTask('default', ['test']);

--- a/README.md
+++ b/README.md
@@ -115,6 +115,24 @@ casper : {
 }
 ```
 
+### Options and Arguments
+CasperJS supports options and arguments on the [command line](http://docs.casperjs.org/en/latest/cli.html).
+
+`casperjs test.js baz --foo=bar`
+
+Grunt tasks can accept additional arguments and grunt-casper will pass these through to CasperJS, for instance
+
+`grunt casper:yourTask:baz:--foo=bar`
+
+will pass `baz` as an argument and `foo` as an option with a value of `bar`.  These are then available in your CasperJS script 
+
+```js
+casper.cli.args.indexOf('baz'); // 0
+casper.cli.options.foo; //bar
+```
+
+Arguments and options will be ignored in `test` mode as CasperJS does not support them.
+
 ## Release History
 
  * 2013-02-01   v0.1.1   Update Task To Run With grunt0.4.0rc7

--- a/tasks/casper.js
+++ b/tasks/casper.js
@@ -8,16 +8,18 @@ module.exports = function (grunt) {
 
   grunt.registerMultiTask('casper', 'execute casperjs tasks', function () {
 
+    var args = Array.prototype.slice.call(arguments);
     var helpers = require('grunt-lib-contrib').init(grunt);
     var options = helpers.options(this, {});
     var done = this.async();
 
     grunt.verbose.writeflags(options, 'Options');
+    grunt.verbose.writeflags(args, 'Arguments');
 
     this.files.forEach(function (file) {
       if (file.src.length) {
         grunt.util.async.forEachSeries(file.src,function (srcFile, next) {
-          casperlib.spawnCasper(srcFile, file.dest, options, next, done);
+          casperlib.spawnCasper(srcFile, file.dest, options, args, next, done);
         }, function (err) {
           if (err) grunt.log.write('error:', err);
           done();

--- a/tasks/lib/casper.js
+++ b/tasks/lib/casper.js
@@ -28,7 +28,7 @@ exports.init = function (grunt) {
     });
   }
 
-  exports.spawnCasper = function(src, dest, options, next, done) {
+  exports.spawnCasper = function(src, dest, options, args, next, done) {
     grunt.verbose.write('Preparing casperjs spawn\n');
     var spawnOpts = [];
 
@@ -61,6 +61,14 @@ exports.init = function (grunt) {
     }
 
     spawnOpts.push(src);
+    
+    if (args.length > 0) {
+      if (options.test) {
+        grunt.log.warn('Arguments not supported for test mode');
+      } else {
+        spawnOpts = spawnOpts.concat(args);
+      }
+    }
 
     spawn(spawnOpts,next,done);
   };

--- a/test/casper_test.js
+++ b/test/casper_test.js
@@ -16,6 +16,7 @@ exports.casper = {
   tests : function(test) {
     var files = [
       'testPass-results.xml',
+      'testArgs-results.xml',
       'testFail-results.xml',
       'testIncludes-results.xml'
     ];

--- a/test/expected/testArgs-results.xml
+++ b/test/expected/testArgs-results.xml
@@ -1,0 +1,1 @@
+<testsuite><testcase classname="test/fixtures/testArgs.js" name="expected baz to be an argument" time="0.307"></testcase><testcase classname="test/fixtures/testArgs.js" name="expected foo to be an option" time="0.001"></testcase><testcase classname="test/fixtures/testArgs.js" name="expected foo option to be bar" time="0"></testcase></testsuite>

--- a/test/fixtures/testArgs.js
+++ b/test/fixtures/testArgs.js
@@ -1,0 +1,14 @@
+var casper = require("casper").create();
+
+casper.start('test/fixtures/basicSite.html');
+
+casper.then(function() {
+   this.test.assert(casper.cli.args.indexOf('baz') == 0, 'expected baz to be an argument');
+   this.test.assert(typeof casper.cli.options['foo'] !== 'undefined', 'expected foo to be an option');
+   this.test.assert(casper.cli.options.foo == 'bar', 'expected foo option to be bar');
+ });
+
+casper.run(function() {
+  this.test.done(3);
+  this.test.renderResults(true, 0, this.cli.get('save') || false);
+});


### PR DESCRIPTION
CasperJS allows passing options and arguments on the command line when
not in test mode.  This patch modifies grunt-casper to pick up
additional arguments passed to the a grunt task and pass them through
to casper when not in test mode.

Includes tests and an update to the readme
