### PR TITLE
fix for multiple files overwriting xunit option

### DIFF
--- a/tasks/lib/casper.js
+++ b/tasks/lib/casper.js
@@ -33,9 +33,11 @@ exports.init = function (grunt) {
     grunt.verbose.write('Preparing casperjs spawn\n');
     var spawnOpts = [];
 
-    if (options.xunit) {
-      if (typeof options.xunit === 'function') {
-        options.xunit = options.xunit(src);
+    if (options.xunit_out) {
+      if (typeof options.xunit_out === 'function') {
+        options.xunit = options.xunit_out(src);
+      } else {
+        options.xunit = options.xunit_out;
       }
     }
 
@@ -54,6 +56,7 @@ exports.init = function (grunt) {
 
     grunt.util._.forEach(options,function(value, option) {
       if (option === 'test') return;
+      if (option === 'xunit_out') return;
       var currentOption = '--' + option + '=' + value;
       grunt.verbose.write('Adding Option ' + currentOption + '\n');
       spawnOpts.push(currentOption);


### PR DESCRIPTION
Thanks for the merge! 

I found an issue where globbed files were overwriting the xunit option, and preventing subsequent tests from getting the correct path. 

Fixed by letting options.xunit be defined during runtime depending on options.xunit_out
