### PR TITLE
Adds possibility to pass options through cli

### DIFF
--- a/tasks/lib/casper.js
+++ b/tasks/lib/casper.js
@@ -86,12 +86,22 @@ exports.init = function (grunt) {
         });
       }
     },
+    
+    getCliOptions: function(){
+      var customArgs = process.argv.slice(3);
+      return customArgs;
+    },
 
     execute : function (src, dest, options, args, next) {
       var self = this;
       grunt.verbose.write('Preparing casperjs spawn\n');
       var spawnOpts = [];
       var cwd = options.cwd || process.cwd();
+      var cliOptions = this.getCliOptions();
+
+      _.forEach(cliOptions, function(value){
+           spawnOpts.push(value);
+      });
 
       //add verbose flag for printing logs to screen
       if (options['log-level'] && !options.verbose) spawnOpts.push('--verbose');


### PR DESCRIPTION
We can take Cli options and send them to our tests, sometimes it is quicker to send values through command line than through gruntfile options. I think this is a good approach to give a second option.
