### PR TITLE
Quick fix for failing tests on windows

### DIFF
--- a/test/casper_test.js
+++ b/test/casper_test.js
@@ -15,7 +15,8 @@ function stripRelative(source) {
   return source.replace(/classname="[^"]+"/g,'classname="STRIPPED"')
     .replace(/time="[^"]+"/g,'time="123"')
     .replace(/duration="[^"]+"/g,'duration="123"')
-    .replace(/timestamp="[^"]+"/g,'timestamp="123"');
+    .replace(/timestamp="[^"]+"/g,'timestamp="123"')
+    .replace(/package="[^"]+"/g,'package="STRIPPED"');
 }
 
 exports.casper = {


### PR DESCRIPTION
Quick fix for Issue #53

Follows the existing approach of stripping data from expected values. A better solution would be to normalise the package path before comparing.
